### PR TITLE
Update Node.js version in GitHub Actions workflow to 20.x

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,7 +11,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: "20.x"
       - name: Install Dependencies
         run: npm ci
       - name: Lint code


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Update Node.js version in GitHub Actions workflow to 20.x.