### PR TITLE
Add GITHUB_TOKEN to GitHub Actions deployment configuration

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,3 +23,4 @@ jobs:
         with:
           branch: gh-pages
           folder: dist
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/build.yaml` file. The change adds a GitHub token to the `jobs` section to facilitate authentication.

* [`.github/workflows/build.yaml`](diffhunk://#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R26): Added `token: ${{ secrets.GITHUB_TOKEN }}` to the `jobs` section to enable authentication.

## Summary by Sourcery

CI:
- Add GITHUB_TOKEN to the GitHub Actions workflow configuration to enable authentication.