### PR TITLE
Refactor GitHub Actions workflow for build and deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,34 +1,25 @@
-name: Build and Deploy
-
 on:
+  # Trigger the workflow on push,
+  # but only for the main branch
   push:
     branches:
       - main
-
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-latest
-
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
         with:
-          node-version: "22"
-
-      - name: Install dependencies
+          node-version: 20
+      - name: Install Dependencies
         run: npm ci
-
-      - name: Run linter
+      - name: Lint codebase
         run: npm run lint
-
-      - name: Build project
+      - name: Build
         run: npm run build
-
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v4
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@v4
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./dist
+          branch: gh-pages
+          folder: dist


### PR DESCRIPTION
Streamline the GitHub Actions workflow by updating the build and deployment steps, including changes to Node.js version and deployment action.

## Summary by Sourcery

Refactor the GitHub Actions workflow to streamline the build and deployment process by combining them into a single job, updating the Node.js version, and changing the deployment action.

CI:
- Refactor the GitHub Actions workflow to combine build and deployment into a single job, triggered only on pushes to the main branch.
- Update the Node.js version used in the workflow from 22 to 20.
- Change the deployment action from 'peaceiris/actions-gh-pages' to 'JamesIves/github-pages-deploy-action'.