### PR TITLE
Add artifact upload step for GitHub Pages deployment

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -31,8 +31,12 @@ jobs:
         run: npm run lint
       - name: Build
         run: npm run build
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: github-pages
+          path: ./dist
       - name: Deploy GitHub Pages site
         uses: actions/deploy-pages@v4.0.5
         with:
-          publish_dir: ./dist
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Introduce an artifact upload step in the GitHub Actions workflow to facilitate the deployment of the GitHub Pages site.

## Summary by Sourcery

CI:
- Add an artifact upload step in the GitHub Actions workflow to store the build output before deployment.