### PR TITLE
Add artifact name for GitHub Pages deployment in workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -39,4 +39,5 @@ jobs:
       - name: Deploy GitHub Pages site
         uses: actions/deploy-pages@v4.0.5
         with:
+          artifact_name: github-pages
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Specify an artifact name for the GitHub Pages deployment to improve clarity and organization in the workflow.

## Summary by Sourcery

CI:
- Specify an artifact name 'github-pages' for the GitHub Pages deployment in the workflow.