### PR TITLE
Update Vite configuration for minigames base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,8 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+  base: "/minigames/",
+});


### PR DESCRIPTION
Set the base path in the Vite configuration to ensure proper routing for minigames.

## Summary by Sourcery

Build:
- Set the base path in the Vite configuration to '/minigames/' to ensure proper routing.