### PR TITLE
fix: improve CI environment variable handling in Playwright config

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
-  forbidOnly: !!process.env.CI,
+  forbidOnly: Boolean(process.env.CI),
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
   /* Opt out of parallel tests on CI. */


### PR DESCRIPTION
This pull request includes a small change to the `playwright.config.ts` file. The change modifies the `forbidOnly` configuration to use the `Boolean` constructor for improved readability and consistency.

* [`playwright.config.ts`](diffhunk://#diff-f679bf1e58e8dddfc6cff0fa37c8e755c8d2cfc9e6b5dc5520a5800beba59a92L20-R20): Changed `forbidOnly` to use `Boolean(process.env.CI)` instead of `!!process.env.CI`.

## Summary by Sourcery

CI:
- Use the `Boolean` constructor to handle the `CI` environment variable in the `forbidOnly` config, improving readability and consistency.