### PR TITLE
Update VSCode settings for spell check and extensions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -12,6 +12,7 @@
     "ms-playwright.playwright",
     "esbenp.prettier-vscode",
     "amatiasq.sort-imports",
-    "shardulm94.trailing-spaces"
+    "shardulm94.trailing-spaces",
+    "usernamehw.errorlens"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,14 @@
 {
-  "cSpell.words": ["minigames", "Zäåö"],
+  "cSpell.words": [
+    "Birman",
+    "Burmilla",
+    "Chartreux",
+    "Colorpoint",
+    "Korat",
+    "minigames",
+    "Shorthair",
+    "tseslint",
+    "Zäåö"
+  ],
   "cSpell.languageSettings": []
 }


### PR DESCRIPTION
Enhance VSCode settings by adding new spell check words and including the Error Lens extension.

## Summary by Sourcery

Configure VSCode to use the Error Lens extension and add project-specific words to the spell checker.

New Features:
- Add custom words relevant to the project to the spell checker dictionary.

Enhancements:
- Integrate the Error Lens extension to improve code analysis and error highlighting within the editor.